### PR TITLE
fix: handle error when member has left guild

### DIFF
--- a/src/events/onReady.ts
+++ b/src/events/onReady.ts
@@ -40,13 +40,17 @@ export const onReady = async (bot: ExtendedClient) => {
 
         if (birthdayRole) {
           for (const memberId of bot.cache) {
-            const member = await guild.members.fetch(memberId);
-            await member.roles.remove(birthdayRole);
+            const member = await guild.members
+              .fetch(memberId)
+              .catch(() => null);
+            if (member) {
+              await member.roles.remove(birthdayRole);
+            }
           }
           bot.cache = [];
           if (ids.length) {
             for (const id of rawIds) {
-              const member = await guild.members.fetch(id);
+              const member = await guild.members.fetch(id).catch(() => null);
               if (member) {
                 await member.roles.add(birthdayRole);
                 bot.cache.push(id);


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

This handles the error when a member has left the guild, silencing the error and allowing the birthday process to continue.
<!--A brief description of what your pull request does.-->

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
